### PR TITLE
add padding option for non-square images

### DIFF
--- a/include/rviz_textured_sphere/sphere_display.h
+++ b/include/rviz_textured_sphere/sphere_display.h
@@ -131,6 +131,7 @@ private:
   FloatProperty* fov_front_property_;
   FloatProperty* fov_rear_property_;
   FloatProperty* blend_angle_property_;
+  BoolProperty* padding_property_;
 
   // Image transport
   std::unique_ptr<image_transport::ImageTransport> it_front_;


### PR DESCRIPTION
I add `padding` option for non-square images.
I'm using fisheye camera with 16:9 `ELP-USB4KHDR01-KL170`, and I want to keep the aspect ratio in the sphere.
So I add `padding` option to keep aspect ratio in the sphere.

### `padding: true`
![rviz_textured_sphere_with_padding](https://user-images.githubusercontent.com/9300063/111632594-faf6f700-8837-11eb-9f05-2baccdbeed3b.png)

### `padding: false`
 ![rviz_textured_sphere_without_padding](https://user-images.githubusercontent.com/9300063/111632547-ee729e80-8837-11eb-82e7-eb76353bec62.png)

